### PR TITLE
Patch for issue #32 and related

### DIFF
--- a/firmware/flash_storage/flashstorage.cpp
+++ b/firmware/flash_storage/flashstorage.cpp
@@ -7,9 +7,14 @@
 #include <string.h>
 #include "serialinterface.h"
 #include <stdio.h>
+#include "Controller.h"
+#include "Geiger.h"
 
 extern uint32_t _binary___binary_data_flash_data_start;
 extern uint32_t _binary___binary_data_flash_data_size;
+
+extern Geiger *system_geiger;
+extern Controller *system_controller;
 
 uint8_t  *flash_data_area_aligned;
 uint32_t  flash_data_area_aligned_size;
@@ -383,4 +388,51 @@ void flashstorage_log_resume() {
 
 uint8_t *flashstorage_log_get() {
   return flash_data_area_aligned+flash_log_base;
+}
+
+void flashstorage_keyval_update() {
+  const char *spulsewidth = flashstorage_keyval_get("PULSEWIDTH");
+  if(spulsewidth != 0) {
+    unsigned int c;
+    sscanf(spulsewidth, "%u", &c);
+    system_geiger->set_pulsewidth(c);
+    system_geiger->pulse_timer_init();
+  }
+  else {
+    system_geiger->set_pulsewidth(6);
+  }
+
+  const char *sbright = flashstorage_keyval_get("BRIGHTNESS");
+  if(sbright != 0) {
+    unsigned int c;
+    sscanf(sbright, "%u", &c);
+    display_set_brightness(c);
+  }
+
+  const char *sbeep = flashstorage_keyval_get("GEIGERBEEP");
+  if(sbeep != 0) {
+    if(!system_controller->m_sleeping) {
+      if(strcmp(sbeep,"true") == 0) {
+        system_geiger->set_beep(true);
+        tick_item("Geiger Beep",true);
+      }
+      else system_geiger->set_beep(false);
+    }
+  }
+
+  const char *scpmcps = flashstorage_keyval_get("CPMCPSAUTO");
+  if(scpmcps != 0) {
+    if(strcmp(scpmcps,"true") == 0) {
+      system_controller->m_cpm_cps_switch = true;
+      tick_item("CPM/CPS Auto",true);
+    }
+  }
+
+  const char *svrem = flashstorage_keyval_get("SVREM");
+  if(strcmp(svrem,"REM") == 0) {
+    tick_item("Roentgen",true);
+  }
+  else {
+    tick_item("Sievert",true);
+  }
 }

--- a/firmware/flash_storage/flashstorage.h
+++ b/firmware/flash_storage/flashstorage.h
@@ -8,6 +8,7 @@ void flashstorage_initialise();
 const char *flashstorage_keyval_get(const char *key);
 void flashstorage_keyval_set(const char *key,const char *value);
 void flashstorage_keyval_by_idx(int idx,char *key,char *val);
+void flashstorage_keyval_update();
 
 void     flashstorage_log_clear();
 int      flashstorage_log_pushback(uint8_t *data,uint32_t size);

--- a/firmware/main.cpp
+++ b/firmware/main.cpp
@@ -114,36 +114,7 @@ int main(void) {
     // Need to refactor out stored settings
     if(c.m_sleeping == false) {   
 
-
-      const char *spulsewidth = flashstorage_keyval_get("PULSEWIDTH");
-      if(spulsewidth != 0) {
-        unsigned int c;
-        sscanf(spulsewidth, "%u", &c);
-        g.set_pulsewidth(c);
-        g.pulse_timer_init();
-      } else {
-        g.set_pulsewidth(6);
-      }
-
-      const char *sbright = flashstorage_keyval_get("BRIGHTNESS");
-      if(sbright != 0) {
-        unsigned int c;
-        sscanf(sbright, "%u", &c);
-        display_set_brightness(c);
-      }
-      
-      const char *sbeep = flashstorage_keyval_get("GEIGERBEEP");
-      if(sbeep != 0) {
-        if(!c.m_sleeping) {
-          if(strcmp(sbeep,"true") == 0) { g.set_beep(true); tick_item("Geiger Beep",true); }
-                                   else g.set_beep(false);
-        }
-      }
-
-      const char *scpmcps = flashstorage_keyval_get("CPMCPSAUTO");
-      if(scpmcps != 0) {
-        if(strcmp(scpmcps,"true") == 0) { c.m_cpm_cps_switch = true; tick_item("CPM/CPS Auto",true); }
-      }
+      flashstorage_keyval_update();
 
       const char *language = flashstorage_keyval_get("LANGUAGE");
       if(language != 0) {
@@ -153,10 +124,6 @@ int main(void) {
         m_gui.set_language(LANGUAGE_ENGLISH);
         tick_item("English",true); 
       }
-
-      const char *svrem = flashstorage_keyval_get("SVREM");
-      if(strcmp(svrem,"REM") == 0) { tick_item("Roentgen",true); }
-                              else { tick_item("Sievert",true);}
     }
 
 

--- a/firmware/serialinterface/serialinterface.cpp
+++ b/firmware/serialinterface/serialinterface.cpp
@@ -397,6 +397,7 @@ void serial_setkeyval_run(char *line) {
   
   if(eqpos==-1) return;
   if(eqpos==0) {		// = on a line ends the command
+    flashstorage_keyval_update();
     command_stack_pop();
     return;
   }


### PR DESCRIPTION
Patch to update device state to values stored in flash.

State init code moved from `main()` to `flashstorage_keyval_update()` and now gets run at startup and after KEYVALSET
