### PR TITLE
Devel

### DIFF
--- a/firmware/log_read/log_read.cpp
+++ b/firmware/log_read/log_read.cpp
@@ -81,7 +81,7 @@ int log_read_block(char *buf) {
    // buf += strlen(buf);
     sprintf(buf,"\"accel_x_start\":%d,\"accel_y_start\":%d,\"accel_z_start\":%d,",flash_log[log_position].accel_x_start,flash_log[log_position].accel_y_start,flash_log[log_position].accel_z_start);
     buf += strlen(buf);
-    sprintf(buf,"\"accel_x_end\":%d,\"accel_y_end\":%d,\"accel_z_end\":%d,",flash_log[log_position].accel_x_end,flash_log[log_position].accel_y_end,flash_log[log_position].accel_z_end);
+    sprintf(buf,"\"accel_x_end\":%d,\"accel_y_end\":%d,\"accel_z_end\":%d}",flash_log[log_position].accel_x_end,flash_log[log_position].accel_y_end,flash_log[log_position].accel_z_end);
     buf += strlen(buf);
    // sprintf(buf,"\"magsensor_start\":%d,\"magsensor_end\":%d}",flash_log[log_position].magsensor_start,flash_log[log_position].magsensor_end);
    // buf += strlen(buf);


### PR DESCRIPTION
Fix JSON format typo created by deletion of extra log variables in previous commit. Log download in JSON is now valid again.

(not sure what all those "merge remote-tracking" things are below, they are just the synchronisation of my own repo with  the Safecast repo...)
